### PR TITLE
Friendlier schema for strongly typed languages (ie: C#)

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 coverage==4.5.2
 coveralls==1.5.1
-pytest==4.1.0
+pytest==5.3.2
 pytest-cov==2.6.1
 twine==1.13.0

--- a/honeybee_model_schema/energy/idealair.py
+++ b/honeybee_model_schema/energy/idealair.py
@@ -33,15 +33,11 @@ class IdealAirSystem(BaseModel):
     type: Enum('IdealAirSystem', {'type': 'IdealAirSystem'})
 
     heating_limit: IdealAirLimit = Schema(
-        default=IdealAirLimit(),
-        description='The heating system limit. If not specified the \
-            default configuraiton will autocalculate the system size.'
+        None
     )
 
     cooling_limit: IdealAirLimit = Schema(
-        default=IdealAirLimit(),
-        description='The cooling system limit. If not specified the \
-            default configuraiton will autocalculate the system size.'
+        None
     )
 
     economizer_type: EconomizerType = EconomizerType.differential_dry_bulb

--- a/honeybee_model_schema/energy/programtype.py
+++ b/honeybee_model_schema/energy/programtype.py
@@ -41,7 +41,8 @@ class PeopleAbridged(BaseModel):
         default=None,
         ge=0,
         le=1,
-        description='Used to specify a fixed latent fraction of heat gain due to people.'
+        description='Used to specify a fixed latent fraction of heat gain due to people. \
+            If left null then Honeybee will autocalculate this value.'
     )
 
     @validator('latent_fraction')

--- a/honeybee_model_schema/energy/programtype.py
+++ b/honeybee_model_schema/energy/programtype.py
@@ -37,8 +37,8 @@ class PeopleAbridged(BaseModel):
         'value is 0.30.'
     )
 
-    latent_fraction: Union[float, str] = Schema(
-        'autocalculate',
+    latent_fraction: float = Schema(
+        default=None,
         ge=0,
         le=1,
         description='Used to specify a fixed latent fraction of heat gain due to people.'

--- a/honeybee_model_schema/energy/programtype.py
+++ b/honeybee_model_schema/energy/programtype.py
@@ -45,12 +45,6 @@ class PeopleAbridged(BaseModel):
             If left null then Honeybee will autocalculate this value.'
     )
 
-    @validator('latent_fraction')
-    def check_string_latent_fraction(cls, v):
-        if not isinstance(v, float) and v != 'autocalculate':
-            raise ValueError('"{}" is not a valid entry for latent_fraction'.format(v))
-
-
     occupancy_schedule: str = Schema(
         ...,
         min_length=1,
@@ -167,7 +161,7 @@ class ElectricEquipmentAbridged(BaseModel):
         ' by electric equipment. Default value is 0.'
     )
 
-    latent_fraction: Union[float, str] = Schema(
+    latent_fraction: float = Schema(
         0,
         ge=0,
         le=1,
@@ -227,7 +221,7 @@ class GasEquipmentAbridged(BaseModel):
         ' by electric equipment.'
     )
 
-    latent_fraction: Union[float, str] = Schema(
+    latent_fraction: float = Schema(
         0,
         ge=0,
         le=1,

--- a/honeybee_model_schema/model.py
+++ b/honeybee_model_schema/model.py
@@ -133,8 +133,8 @@ class Outdoors(BaseModel):
         default=None
     )
 
-    view_factor: Union[str, float] = Schema(
-        'autocalculate',
+    view_factor: float = Schema(
+        default=None,
         ge=0,
         le=1
     )

--- a/honeybee_model_schema/model.py
+++ b/honeybee_model_schema/model.py
@@ -136,7 +136,8 @@ class Outdoors(BaseModel):
     view_factor: float = Schema(
         default=None,
         ge=0,
-        le=1
+        le=1,
+        description='If left null then Honeybee will autocalculate this value.'
     )
 
 

--- a/honeybee_model_schema/samples/ideal_air_detailed.json
+++ b/honeybee_model_schema/samples/ideal_air_detailed.json
@@ -1,7 +1,13 @@
 {
     "type": "IdealAirSystem",
-    "heating_limit": 2000.0,
-    "cooling_limit": 3500.0,
+    "heating_limit": {
+        "config": "FixedValue",
+        "value": 2000.0
+    },
+    "cooling_limit": {
+        "config": "FixedValue",
+        "value": 3500.0
+    },
     "economizer_type": "DifferentialEnthalpy",
     "demand_controlled_ventilation": true,
     "sensible_heat_recovery": 0.75,

--- a/honeybee_model_schema/samples/model_complete_multi_zone_office.json
+++ b/honeybee_model_schema/samples/model_complete_multi_zone_office.json
@@ -439,7 +439,7 @@
                         "name": "Generic Office People",
                         "people_per_area": 0.0565,
                         "radiant_fraction": 0.3,
-                        "latent_fraction": "autocalculate",
+                        "latent_fraction": null,
                         "occupancy_schedule": "Generic Office Occupancy",
                         "activity_schedule": "Generic Office Activity"
                     },
@@ -1781,7 +1781,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -1824,7 +1824,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -1869,7 +1869,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -1912,7 +1912,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -1957,7 +1957,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -2000,7 +2000,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -2045,7 +2045,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -2088,7 +2088,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -2238,7 +2238,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -2281,7 +2281,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -2326,7 +2326,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -2369,7 +2369,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -2414,7 +2414,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -2457,7 +2457,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -2502,7 +2502,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -2545,7 +2545,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -2692,7 +2692,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 },
                 {
@@ -2735,7 +2735,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 },
                 {
@@ -2773,7 +2773,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 },
                 {
@@ -2811,7 +2811,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 }
             ]

--- a/honeybee_model_schema/samples/model_complete_single_zone_office.json
+++ b/honeybee_model_schema/samples/model_complete_single_zone_office.json
@@ -415,7 +415,7 @@
                         "name": "Generic Office People",
                         "people_per_area": 0.0565,
                         "radiant_fraction": 0.3,
-                        "latent_fraction": "autocalculate",
+                        "latent_fraction": null,
                         "occupancy_schedule": "Generic Office Occupancy",
                         "activity_schedule": "Generic Office Activity"
                     },
@@ -1758,7 +1758,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -1802,7 +1802,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ],
@@ -1847,7 +1847,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ],
@@ -1930,7 +1930,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 },
                 {
@@ -1973,7 +1973,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -2016,7 +2016,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             },
                             "outdoor_shades": [
                                 {
@@ -2139,7 +2139,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 },
                 {
@@ -2182,7 +2182,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 }
             ],

--- a/honeybee_model_schema/samples/model_complete_single_zone_office_detailed_loads.json
+++ b/honeybee_model_schema/samples/model_complete_single_zone_office_detailed_loads.json
@@ -1590,7 +1590,7 @@
                         "name": "Generic Office People",
                         "people_per_area": 0.0565,
                         "radiant_fraction": 0.3,
-                        "latent_fraction": "autocalculate",
+                        "latent_fraction": null,
                         "occupancy_schedule": "Generic Office Occupancy",
                         "activity_schedule": "Generic Office Activity"
                     },
@@ -1793,7 +1793,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 },
                 {

--- a/honeybee_model_schema/samples/model_complete_single_zone_office_fixed_interval.json
+++ b/honeybee_model_schema/samples/model_complete_single_zone_office_fixed_interval.json
@@ -385,7 +385,7 @@
                         "name": "Generic Office People",
                         "people_per_area": 0.0565,
                         "radiant_fraction": 0.3,
-                        "latent_fraction": "autocalculate",
+                        "latent_fraction": null,
                         "occupancy_schedule": "Generic Office Occupancy",
                         "activity_schedule": "Generic Office Activity"
                     },
@@ -19199,7 +19199,7 @@
                         "name": "Generic Office People",
                         "people_per_area": 0.0565,
                         "radiant_fraction": 0.3,
-                        "latent_fraction": "autocalculate",
+                        "latent_fraction": null,
                         "occupancy_schedule": "Random Occupancy",
                         "activity_schedule": "Generic Office Activity"
                     }
@@ -19286,7 +19286,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -19329,7 +19329,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ],
@@ -19374,7 +19374,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ],
@@ -19457,7 +19457,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 },
                 {
@@ -19500,7 +19500,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -19543,7 +19543,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             },
                             "outdoor_shades": [
                                 {
@@ -19666,7 +19666,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 },
                 {
@@ -19709,7 +19709,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 }
             ]

--- a/honeybee_model_schema/samples/model_complete_with_humidity_setpoints.json
+++ b/honeybee_model_schema/samples/model_complete_with_humidity_setpoints.json
@@ -371,7 +371,7 @@
                         "name": "2013::Hospital::ICU_PatRm_People",
                         "people_per_area": 0.05381957525591208,
                         "radiant_fraction": 0.3,
-                        "latent_fraction": "autocalculate",
+                        "latent_fraction": null,
                         "occupancy_schedule": "Hospital BLDG_OCC_EXTD_SCH",
                         "activity_schedule": "Hospital ACTIVITY_SCH"
                     },
@@ -1470,7 +1470,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -1513,7 +1513,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             },
                             "outdoor_shades": [
                                 {

--- a/honeybee_model_schema/samples/model_multi_zone_single_family_house.json
+++ b/honeybee_model_schema/samples/model_multi_zone_single_family_house.json
@@ -531,7 +531,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -574,7 +574,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -619,7 +619,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -662,7 +662,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -707,7 +707,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -750,7 +750,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -795,7 +795,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -838,7 +838,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -992,7 +992,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -1035,7 +1035,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -1080,7 +1080,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -1123,7 +1123,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -1168,7 +1168,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -1211,7 +1211,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -1256,7 +1256,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -1299,7 +1299,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]
@@ -1453,7 +1453,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 },
                 {
@@ -1496,7 +1496,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 },
                 {
@@ -1534,7 +1534,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 },
                 {
@@ -1572,7 +1572,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 }
             ]

--- a/honeybee_model_schema/samples/model_shoe_box.json
+++ b/honeybee_model_schema/samples/model_shoe_box.json
@@ -320,7 +320,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -363,7 +363,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         },
                         {
@@ -406,7 +406,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ]

--- a/honeybee_model_schema/samples/model_single_zone_tiny_house.json
+++ b/honeybee_model_schema/samples/model_single_zone_tiny_house.json
@@ -508,7 +508,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -552,7 +552,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ],
@@ -597,7 +597,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             }
                         }
                     ],
@@ -680,7 +680,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 },
                 {
@@ -723,7 +723,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     },
                     "apertures": [
                         {
@@ -766,7 +766,7 @@
                                 "type": "Outdoors",
                                 "sun_exposure": true,
                                 "wind_exposure": true,
-                                "view_factor": "autocalculate"
+                                "view_factor": null
                             },
                             "outdoor_shades": [
                                 {
@@ -889,7 +889,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 },
                 {
@@ -932,7 +932,7 @@
                         "type": "Outdoors",
                         "sun_exposure": true,
                         "wind_exposure": true,
-                        "view_factor": "autocalculate"
+                        "view_factor": null
                     }
                 }
             ],


### PR DESCRIPTION
Python works nicely with loosely typed value, however this is more difficult to do with strongly
typed languages (ie: C#). The changes proposed here make it easier for such languages to
serialize/deserialize to and from json. As a general rule of thumb it is ok to use multiple type
options for complex objects, less so for core variable types (ints, strings, bools, floats etc...).

The changes proposed will offer similar behaviour to what was previously set up. The following implementations changes on Honeybee's side will be required:
* Ideal Air Systems: The heating/cooling limits are now an object from which the config (no limit, autocalculate or fixed value) can be pulled and if  a fixed value is specified it can be pulled also
* Program Type: The latent fraction is set to a float or is null. If it is null then Honeybee should assume that it is an "autocalculate" value
* Model Outdoors: The view factor is set to a float or is null. If it is null then Honeybee should assume that it is an "autocalculate" value