### PR TITLE
feat(pip): Set up deploment to PyPI

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 echo "Building distribution"
-# python setup.py sdist bdist_wheel
+python setup.py sdist bdist_wheel
 echo "Pushing new version to PyPi"
-# twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD
+twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD

--- a/honeybee_schema/_openapi.py
+++ b/honeybee_schema/_openapi.py
@@ -8,7 +8,7 @@ _base_open_api = {
     "servers": [],
     "info": {
         "description": "",
-        "version": "1.0.0",
+        "version": "1.3.0",
         "title": "",
         "contact": {
             "name": "Ladybug Tools",


### PR DESCRIPTION
This officially puts the honeybee_schema package on PyPI so that it can be used by other schema repos (like the future dragonfly_schema repo).